### PR TITLE
Update for CHS Streaming API (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ._*
 build
 kafka-management-tool-*.zip
+kafka-management-tool
 build.log
 test.xml
 lint.txt

--- a/schemas/resource-changed.go
+++ b/schemas/resource-changed.go
@@ -1,0 +1,9 @@
+package schemas
+
+// ResourceChanged resource changed
+type ResourceChanged struct {
+	ResourceKind string `json:"resource_kind" avro:"resource_kind"`
+	ChangeType   string `json:"change_type" avro:"change_type"`
+	PublishedAt  string `json:"published_at" avro:"published_at"`
+	ResourceURI  string `json:"resource_uri" avro:"resource_uri"`
+}

--- a/schemas/resource-changed.go
+++ b/schemas/resource-changed.go
@@ -1,9 +1,17 @@
 package schemas
 
-// ResourceChanged resource changed
+// EventRecord - describes the event the resource was changed for
+type EventRecord struct {
+	PublishedAt   string   `json:"published_at" avro:"published_at"`
+	Type          string   `json:"type" avro:"type"`
+	FieldsChanged []string `json:"fields_changed" avro:"fields_changed"`
+}
+
+// ResourceChanged resource changed (json is for output in this utility, nothing to do with input to kafka api)
 type ResourceChanged struct {
-	ResourceKind string `json:"resource_kind" avro:"resource_kind"`
-	ChangeType   string `json:"change_type" avro:"change_type"`
-	PublishedAt  string `json:"published_at" avro:"published_at"`
-	ResourceURI  string `json:"resource_uri" avro:"resource_uri"`
+	ResourceKind string      `json:"resource_kind" avro:"resource_kind"`
+	ResourceURI  string      `json:"resource_uri" avro:"resource_uri"`
+	ContextID    string      `json:"context_id" avro:"context_id"`
+	DeletedData  string      `json:"deleted_data" avro:"deleted_data"`
+	Event        EventRecord `json:"event" avro:"event"`
 }

--- a/schemas/schemas.go
+++ b/schemas/schemas.go
@@ -18,6 +18,8 @@ func IdentifySchema(topicName string) interface{} {
 		return &FilingReceived{}
 	case "filing-processed":
 		return &FilingProcessed{}
+	case "resource_changed":
+		return &ResourceChanged{}
 	}
 	return nil
 }

--- a/schemas/schemas.go
+++ b/schemas/schemas.go
@@ -18,7 +18,7 @@ func IdentifySchema(topicName string) interface{} {
 		return &FilingReceived{}
 	case "filing-processed":
 		return &FilingProcessed{}
-	case "resource_changed":
+	case "resource-changed":
 		return &ResourceChanged{}
 	}
 	return nil


### PR DESCRIPTION
Add resource_change schema and update it to the latest version (with the event object). This allows this utility to work with the CHS Streaming API